### PR TITLE
Direct state in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Direct state context
   - No breaking change in API, but it may behave differently
+- Support custom context
 
 ## [3.0.0] - 2019-05-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Direct state context
+  - No breaking change in API, but it may behave differently
 
 ## [3.0.0] - 2019-05-18
 ### Changed

--- a/dist/ReduxProvider.js
+++ b/dist/ReduxProvider.js
@@ -3,20 +3,26 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.ReduxProvider = exports.defaultContext = void 0;
+exports.ReduxProvider = exports.defaultContext = exports.createCustomContext = void 0;
 
 var _react = require("react");
 
 var _utils = require("./utils");
 
+// -------------------------------------------------------
 // context
+// -------------------------------------------------------
 var warningObject = {
-  get dispatch() {
-    throw new Error('Please use <ReduxProvider store={store}>');
+  get state() {
+    throw new Error('Please use <TrackedProvider ...>');
   },
 
-  get getState() {
-    throw new Error('Please use <ReduxProvider store={store}>');
+  get dispatch() {
+    throw new Error('Please use <TrackedProvider ...>');
+  },
+
+  get subscribe() {
+    throw new Error('Please use <TrackedProvider ...>');
   }
 
 };
@@ -25,7 +31,17 @@ var calculateChangedBits = function calculateChangedBits(a, b) {
   return a.dispatch !== b.dispatch || a.subscribe !== b.subscribe ? 1 : 0;
 };
 
-var defaultContext = (0, _react.createContext)(warningObject, calculateChangedBits);
+var createCustomContext = function createCustomContext() {
+  var w = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : warningObject;
+  var c = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : calculateChangedBits;
+  return (0, _react.createContext)(w, c);
+};
+
+exports.createCustomContext = createCustomContext;
+var defaultContext = createCustomContext(); // -------------------------------------------------------
+// provider
+// -------------------------------------------------------
+
 exports.defaultContext = defaultContext;
 
 var ReduxProvider = function ReduxProvider(_ref) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6,7 +6,13 @@ Object.defineProperty(exports, "__esModule", {
 Object.defineProperty(exports, "ReduxProvider", {
   enumerable: true,
   get: function get() {
-    return _provider.ReduxProvider;
+    return _ReduxProvider.ReduxProvider;
+  }
+});
+Object.defineProperty(exports, "createCustomContext", {
+  enumerable: true,
+  get: function get() {
+    return _ReduxProvider.createCustomContext;
   }
 });
 Object.defineProperty(exports, "useReduxDispatch", {
@@ -40,7 +46,7 @@ Object.defineProperty(exports, "useReduxSelectors", {
   }
 });
 
-var _provider = require("./provider");
+var _ReduxProvider = require("./ReduxProvider");
 
 var _useReduxDispatch = require("./useReduxDispatch");
 

--- a/dist/provider.js
+++ b/dist/provider.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.ReduxProvider = exports.ReduxStoreContext = void 0;
+exports.ReduxProvider = exports.defaultContext = void 0;
 
 var _react = require("react");
 
@@ -27,11 +27,13 @@ var calculateChangedBits = function calculateChangedBits(a, b) {
   return a.dispatch !== b.dispatch || a.subscribe !== b.subscribe ? 1 : 0;
 };
 
-var ReduxStoreContext = (0, _react.createContext)(warningObject, calculateChangedBits);
-exports.ReduxStoreContext = ReduxStoreContext;
+var defaultContext = (0, _react.createContext)(warningObject, calculateChangedBits);
+exports.defaultContext = defaultContext;
 
 var ReduxProvider = function ReduxProvider(_ref) {
   var store = _ref.store,
+      _ref$customContext = _ref.customContext,
+      customContext = _ref$customContext === void 0 ? defaultContext : _ref$customContext,
       children = _ref.children;
   var forceUpdate = (0, _utils.useForceUpdate)();
   var state = store.getState();
@@ -61,7 +63,7 @@ var ReduxProvider = function ReduxProvider(_ref) {
     });
     return unsubscribe;
   }, [store, forceUpdate]);
-  return (0, _react.createElement)(ReduxStoreContext.Provider, {
+  return (0, _react.createElement)(customContext.Provider, {
     value: {
       state: state,
       dispatch: store.dispatch,

--- a/dist/provider.js
+++ b/dist/provider.js
@@ -7,8 +7,6 @@ exports.ReduxProvider = exports.defaultContext = void 0;
 
 var _react = require("react");
 
-var _batchedUpdates = require("./batchedUpdates");
-
 var _utils = require("./utils");
 
 // context
@@ -38,11 +36,9 @@ var ReduxProvider = function ReduxProvider(_ref) {
   var forceUpdate = (0, _utils.useForceUpdate)();
   var state = store.getState();
   var listeners = (0, _react.useRef)([]);
-  (0, _react.useEffect)(function () {
-    (0, _batchedUpdates.batchedUpdates)(function () {
-      listeners.current.forEach(function (listener) {
-        return listener(state);
-      });
+  (0, _utils.useIsomorphicLayoutEffect)(function () {
+    listeners.current.forEach(function (listener) {
+      return listener(state);
     });
   }, [state]);
   var subscribe = (0, _react.useCallback)(function (listener) {

--- a/dist/provider.js
+++ b/dist/provider.js
@@ -23,8 +23,8 @@ var warningObject = {
 
 };
 
-var calculateChangedBits = function calculateChangedBits() {
-  return 0;
+var calculateChangedBits = function calculateChangedBits(a, b) {
+  return a.dispatch !== b.dispatch || a.subscribe !== b.subscribe ? 1 : 0;
 };
 
 var ReduxStoreContext = (0, _react.createContext)(warningObject, calculateChangedBits);

--- a/dist/useReduxDispatch.js
+++ b/dist/useReduxDispatch.js
@@ -7,12 +7,12 @@ exports.useReduxDispatch = void 0;
 
 var _react = require("react");
 
-var _provider = require("./provider");
+var _ReduxProvider = require("./ReduxProvider");
 
 var useReduxDispatch = function useReduxDispatch() {
   var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var _opts$customContext = opts.customContext,
-      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
+      customContext = _opts$customContext === void 0 ? _ReduxProvider.defaultContext : _opts$customContext;
 
   var _useContext = (0, _react.useContext)(customContext),
       dispatch = _useContext.dispatch;

--- a/dist/useReduxDispatch.js
+++ b/dist/useReduxDispatch.js
@@ -10,7 +10,11 @@ var _react = require("react");
 var _provider = require("./provider");
 
 var useReduxDispatch = function useReduxDispatch() {
-  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+  var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var _opts$customContext = opts.customContext,
+      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
+
+  var _useContext = (0, _react.useContext)(customContext),
       dispatch = _useContext.dispatch;
 
   return dispatch;

--- a/dist/useReduxDispatch.js
+++ b/dist/useReduxDispatch.js
@@ -10,8 +10,10 @@ var _react = require("react");
 var _provider = require("./provider");
 
 var useReduxDispatch = function useReduxDispatch() {
-  var store = (0, _react.useContext)(_provider.ReduxStoreContext);
-  return store.dispatch;
+  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+      dispatch = _useContext.dispatch;
+
+  return dispatch;
 };
 
 exports.useReduxDispatch = useReduxDispatch;

--- a/dist/useReduxSelectors.js
+++ b/dist/useReduxSelectors.js
@@ -62,10 +62,12 @@ var runSelector = function runSelector(state, selector) {
 };
 
 var useReduxSelectors = function useReduxSelectors(selectorMap) {
-  var forceUpdate = (0, _utils.useForceUpdate)(); // redux store&state
+  var forceUpdate = (0, _utils.useForceUpdate)(); // redux state
 
-  var store = (0, _react.useContext)(_provider.ReduxStoreContext);
-  var state = store.getState(); // mapped result
+  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+      state = _useContext.state,
+      subscribe = _useContext.subscribe; // mapped result
+
 
   var keys = Object.keys(selectorMap);
   var mapped = createMap(keys, function (key) {
@@ -85,9 +87,8 @@ var useReduxSelectors = function useReduxSelectors(selectorMap) {
   }); // subscription
 
   (0, _react.useEffect)(function () {
-    var callback = function callback() {
+    var callback = function callback(nextState) {
       try {
-        var nextState = store.getState();
         var changed = false;
         var nextMapped = createMap(lastTracked.current.keys, function (key) {
           var lastResult = lastTracked.current.mapped[key];
@@ -109,14 +110,11 @@ var useReduxSelectors = function useReduxSelectors(selectorMap) {
         // detect erorr (probably stale props)
         forceUpdate();
       }
-    }; // run once in case the state is already changed
+    };
 
-
-    callback();
-    var unsubscribe = store.subscribe(callback);
+    var unsubscribe = subscribe(callback);
     return unsubscribe;
-  }, [store]); // eslint-disable-line react-hooks/exhaustive-deps
-
+  }, [subscribe, forceUpdate]);
   return trapped.proxy;
 };
 

--- a/dist/useReduxSelectors.js
+++ b/dist/useReduxSelectors.js
@@ -11,7 +11,7 @@ var _memoizeState = _interopRequireDefault(require("memoize-state"));
 
 var _withKnownUsage = require("with-known-usage");
 
-var _provider = require("./provider");
+var _ReduxProvider = require("./ReduxProvider");
 
 var _utils = require("./utils");
 
@@ -64,7 +64,7 @@ var runSelector = function runSelector(state, selector) {
 var useReduxSelectors = function useReduxSelectors(selectorMap) {
   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
   var _opts$customContext = opts.customContext,
-      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
+      customContext = _opts$customContext === void 0 ? _ReduxProvider.defaultContext : _opts$customContext;
   var forceUpdate = (0, _utils.useForceUpdate)(); // redux state
 
   var _useContext = (0, _react.useContext)(customContext),

--- a/dist/useReduxSelectors.js
+++ b/dist/useReduxSelectors.js
@@ -62,9 +62,12 @@ var runSelector = function runSelector(state, selector) {
 };
 
 var useReduxSelectors = function useReduxSelectors(selectorMap) {
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var _opts$customContext = opts.customContext,
+      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
   var forceUpdate = (0, _utils.useForceUpdate)(); // redux state
 
-  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+  var _useContext = (0, _react.useContext)(customContext),
       state = _useContext.state,
       subscribe = _useContext.subscribe; // mapped result
 

--- a/dist/useReduxState.js
+++ b/dist/useReduxState.js
@@ -7,7 +7,7 @@ exports.useReduxState = void 0;
 
 var _react = require("react");
 
-var _provider = require("./provider");
+var _ReduxProvider = require("./ReduxProvider");
 
 var _utils = require("./utils");
 
@@ -16,7 +16,7 @@ var _deepProxy = require("./deepProxy");
 var useReduxState = function useReduxState() {
   var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var _opts$customContext = opts.customContext,
-      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
+      customContext = _opts$customContext === void 0 ? _ReduxProvider.defaultContext : _opts$customContext;
   var forceUpdate = (0, _utils.useForceUpdate)();
 
   var _useContext = (0, _react.useContext)(customContext),

--- a/dist/useReduxState.js
+++ b/dist/useReduxState.js
@@ -16,8 +16,11 @@ var _deepProxy = require("./deepProxy");
 var useReduxState = function useReduxState() {
   var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var forceUpdate = (0, _utils.useForceUpdate)();
-  var store = (0, _react.useContext)(_provider.ReduxStoreContext);
-  var state = store.getState();
+
+  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+      state = _useContext.state,
+      subscribe = _useContext.subscribe;
+
   var affected = new WeakMap();
   var lastTracked = (0, _react.useRef)(null);
   (0, _utils.useIsomorphicLayoutEffect)(function () {
@@ -35,22 +38,18 @@ var useReduxState = function useReduxState() {
     };
   });
   (0, _react.useEffect)(function () {
-    var callback = function callback() {
-      var nextState = store.getState();
+    var callback = function callback(nextState) {
       var changed = (0, _deepProxy.isDeepChanged)(lastTracked.current.state, nextState, lastTracked.current.affected, lastTracked.current.cache, lastTracked.current.assumeChangedIfNotAffected);
 
       if (changed) {
         lastTracked.current.state = nextState;
         forceUpdate();
       }
-    }; // run once in case the state is already changed
+    };
 
-
-    callback();
-    var unsubscribe = store.subscribe(callback);
+    var unsubscribe = subscribe(callback);
     return unsubscribe;
-  }, [store]); // eslint-disable-line react-hooks/exhaustive-deps
-
+  }, [subscribe, forceUpdate]);
   var proxyCache = (0, _react.useRef)(new WeakMap()); // per-hook proxyCache
 
   return (0, _deepProxy.createDeepProxy)(state, affected, proxyCache.current);

--- a/dist/useReduxState.js
+++ b/dist/useReduxState.js
@@ -15,9 +15,11 @@ var _deepProxy = require("./deepProxy");
 
 var useReduxState = function useReduxState() {
   var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var _opts$customContext = opts.customContext,
+      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
   var forceUpdate = (0, _utils.useForceUpdate)();
 
-  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+  var _useContext = (0, _react.useContext)(customContext),
       state = _useContext.state,
       subscribe = _useContext.subscribe;
 

--- a/dist/useReduxStateRich.js
+++ b/dist/useReduxStateRich.js
@@ -35,9 +35,12 @@ var useTrapped = function useTrapped(state) {
 };
 
 var useReduxStateRich = function useReduxStateRich() {
+  var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var _opts$customContext = opts.customContext,
+      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
   var forceUpdate = (0, _utils.useForceUpdate)(); // redux state
 
-  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+  var _useContext = (0, _react.useContext)(customContext),
       state = _useContext.state,
       subscribe = _useContext.subscribe; // trapped
 

--- a/dist/useReduxStateRich.js
+++ b/dist/useReduxStateRich.js
@@ -9,7 +9,7 @@ var _react = require("react");
 
 var _proxyequal = require("proxyequal");
 
-var _provider = require("./provider");
+var _ReduxProvider = require("./ReduxProvider");
 
 var _utils = require("./utils");
 
@@ -37,7 +37,7 @@ var useTrapped = function useTrapped(state) {
 var useReduxStateRich = function useReduxStateRich() {
   var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var _opts$customContext = opts.customContext,
-      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
+      customContext = _opts$customContext === void 0 ? _ReduxProvider.defaultContext : _opts$customContext;
   var forceUpdate = (0, _utils.useForceUpdate)(); // redux state
 
   var _useContext = (0, _react.useContext)(customContext),

--- a/dist/useReduxStateRich.js
+++ b/dist/useReduxStateRich.js
@@ -35,10 +35,12 @@ var useTrapped = function useTrapped(state) {
 };
 
 var useReduxStateRich = function useReduxStateRich() {
-  var forceUpdate = (0, _utils.useForceUpdate)(); // redux store&state
+  var forceUpdate = (0, _utils.useForceUpdate)(); // redux state
 
-  var store = (0, _react.useContext)(_provider.ReduxStoreContext);
-  var state = store.getState(); // trapped
+  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+      state = _useContext.state,
+      subscribe = _useContext.subscribe; // trapped
+
 
   var trapped = useTrapped(state); // ref
 
@@ -51,22 +53,18 @@ var useReduxStateRich = function useReduxStateRich() {
   }); // subscription
 
   (0, _react.useEffect)(function () {
-    var callback = function callback() {
-      var nextState = store.getState();
+    var callback = function callback(nextState) {
       var changed = !(0, _proxyequal.proxyEqual)(lastTracked.current.state, nextState, lastTracked.current.affected);
 
       if (changed) {
         lastTracked.current.state = nextState;
         forceUpdate();
       }
-    }; // run once in case the state is already changed
+    };
 
-
-    callback();
-    var unsubscribe = store.subscribe(callback);
+    var unsubscribe = subscribe(callback);
     return unsubscribe;
-  }, [store]); // eslint-disable-line react-hooks/exhaustive-deps
-
+  }, [subscribe, forceUpdate]);
   return trapped.state;
 };
 

--- a/dist/useReduxStateSimple.js
+++ b/dist/useReduxStateSimple.js
@@ -7,7 +7,7 @@ exports.useReduxStateSimple = void 0;
 
 var _react = require("react");
 
-var _provider = require("./provider");
+var _ReduxProvider = require("./ReduxProvider");
 
 var _utils = require("./utils");
 
@@ -17,7 +17,7 @@ var _utils = require("./utils");
 var useReduxStateSimple = function useReduxStateSimple() {
   var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var _opts$customContext = opts.customContext,
-      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
+      customContext = _opts$customContext === void 0 ? _ReduxProvider.defaultContext : _opts$customContext;
   var forceUpdate = (0, _utils.useForceUpdate)();
 
   var _useContext = (0, _react.useContext)(customContext),

--- a/dist/useReduxStateSimple.js
+++ b/dist/useReduxStateSimple.js
@@ -16,7 +16,11 @@ var _utils = require("./utils");
 // -------------------------------------------------------
 var useReduxStateSimple = function useReduxStateSimple() {
   var forceUpdate = (0, _utils.useForceUpdate)();
-  var store = (0, _react.useContext)(_provider.ReduxStoreContext);
+
+  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+      state = _useContext.state,
+      subscribe = _useContext.subscribe;
+
   var used = (0, _react.useRef)({});
   var handler = (0, _react.useMemo)(function () {
     return {
@@ -26,14 +30,12 @@ var useReduxStateSimple = function useReduxStateSimple() {
       }
     };
   }, []);
-  var state = store.getState();
   var lastState = (0, _react.useRef)(null);
   (0, _utils.useIsomorphicLayoutEffect)(function () {
     lastState.current = state;
   });
   (0, _react.useEffect)(function () {
-    var callback = function callback() {
-      var nextState = store.getState();
+    var callback = function callback(nextState) {
       var changed = Object.keys(used.current).find(function (key) {
         return lastState.current[key] !== nextState[key];
       });
@@ -41,11 +43,9 @@ var useReduxStateSimple = function useReduxStateSimple() {
       if (changed) {
         forceUpdate();
       }
-    }; // run once in case the state is already changed
+    };
 
-
-    callback();
-    var unsubscribe = store.subscribe(callback);
+    var unsubscribe = subscribe(callback);
 
     var cleanup = function cleanup() {
       unsubscribe();
@@ -53,8 +53,7 @@ var useReduxStateSimple = function useReduxStateSimple() {
     };
 
     return cleanup;
-  }, [store]); // eslint-disable-line react-hooks/exhaustive-deps
-
+  }, [subscribe, forceUpdate]);
   return new Proxy(state, handler);
 };
 

--- a/dist/useReduxStateSimple.js
+++ b/dist/useReduxStateSimple.js
@@ -15,9 +15,12 @@ var _utils = require("./utils");
 // simple version: one depth comparison
 // -------------------------------------------------------
 var useReduxStateSimple = function useReduxStateSimple() {
+  var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var _opts$customContext = opts.customContext,
+      customContext = _opts$customContext === void 0 ? _provider.defaultContext : _opts$customContext;
   var forceUpdate = (0, _utils.useForceUpdate)();
 
-  var _useContext = (0, _react.useContext)(_provider.ReduxStoreContext),
+  var _useContext = (0, _react.useContext)(customContext),
       state = _useContext.state,
       subscribe = _useContext.subscribe;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reactive-react-redux",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reactive-react-redux",
-  "version": "3.0.0",
+  "version": "4.0.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reactive-react-redux",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reactive-react-redux",
   "description": "React Redux binding with React Hooks and Proxy",
-  "version": "3.0.0",
+  "version": "4.0.0-alpha.0",
   "author": "Daishi Kato",
   "repository": {
     "type": "git",
@@ -81,8 +81,8 @@
     "webpack-dev-server": "^3.7.1"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "redux": ">=4.0.0"
+    "react": ">=16.8.6",
+    "redux": ">=4.0.1"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reactive-react-redux",
   "description": "React Redux binding with React Hooks and Proxy",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "author": "Daishi Kato",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "webpack-dev-server": "^3.7.1"
   },
   "peerDependencies": {
-    "react": ">=16.8.6",
-    "redux": ">=4.0.1"
+    "react": ">=16.8.0",
+    "redux": ">=4.0.0"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reactive-react-redux",
   "description": "React Redux binding with React Hooks and Proxy",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "author": "Daishi Kato",
   "repository": {
     "type": "git",

--- a/src/ReduxProvider.js
+++ b/src/ReduxProvider.js
@@ -8,19 +8,36 @@ import {
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 
+// -------------------------------------------------------
 // context
+// -------------------------------------------------------
+
 const warningObject = {
-  get dispatch() {
-    throw new Error('Please use <ReduxProvider store={store}>');
+  get state() {
+    throw new Error('Please use <TrackedProvider ...>');
   },
-  get getState() {
-    throw new Error('Please use <ReduxProvider store={store}>');
+  get dispatch() {
+    throw new Error('Please use <TrackedProvider ...>');
+  },
+  get subscribe() {
+    throw new Error('Please use <TrackedProvider ...>');
   },
 };
+
 const calculateChangedBits = (a, b) => (
   a.dispatch !== b.dispatch || a.subscribe !== b.subscribe ? 1 : 0
 );
-export const defaultContext = createContext(warningObject, calculateChangedBits);
+
+export const createCustomContext = (
+  w = warningObject,
+  c = calculateChangedBits,
+) => createContext(w, c);
+
+export const defaultContext = createCustomContext();
+
+// -------------------------------------------------------
+// provider
+// -------------------------------------------------------
 
 export const ReduxProvider = ({
   store,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,12 +26,12 @@ type Opts = {
   customContext?: CustomContext;
 };
 
-export const useReduxState: <S extends {}>(opts: Opts) => S;
+export const useReduxState: <S extends {}>(opts?: Opts) => S;
 
 export const useReduxSelectors: <S extends {}, M extends {}>(
   selectors: { [K in keyof M]: (state: S) => M[K] },
-  opts: Opts,
+  opts?: Opts,
 ) => M;
 
-export const useReduxStateSimple: <S extends {}>(opts: Opts) => S;
-export const useReduxStateRich: <S extends {}>(opts: Opts) => S;
+export const useReduxStateSimple: <S extends {}>(opts?: Opts) => S;
+export const useReduxStateRich: <S extends {}>(opts?: Opts) => S;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,8 +6,13 @@ import {
   Store,
 } from 'redux';
 
+type CustomContext = React.Context<unknown>;
+
+export type createCustomContext = () => CustomContext;
+
 export type ReduxProviderProps<S, A extends Action> = {
   store: Store<S, A>;
+  customContext?: CustomContext;
 };
 
 export type ReduxProviderType<S = unknown, A extends Action = AnyAction>
@@ -17,11 +22,16 @@ export const ReduxProvider: ReduxProviderType;
 
 export const useReduxDispatch: <A extends Action>() => Dispatch<A>;
 
-export const useReduxState: <S extends {}>() => S;
+type Opts = {
+  customContext?: CustomContext;
+};
+
+export const useReduxState: <S extends {}>(opts: Opts) => S;
 
 export const useReduxSelectors: <S extends {}, M extends {}>(
   selectors: { [K in keyof M]: (state: S) => M[K] },
+  opts: Opts,
 ) => M;
 
-export const useReduxStateSimple: <S extends {}>() => S;
-export const useReduxStateRich: <S extends {}>() => S;
+export const useReduxStateSimple: <S extends {}>(opts: Opts) => S;
+export const useReduxStateRich: <S extends {}>(opts: Opts) => S;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export { ReduxProvider } from './provider';
+export { ReduxProvider, createCustomContext } from './ReduxProvider';
 export { useReduxDispatch } from './useReduxDispatch';
 export { useReduxState } from './useReduxState';
 

--- a/src/provider.js
+++ b/src/provider.js
@@ -22,9 +22,13 @@ const warningObject = {
 const calculateChangedBits = (a, b) => (
   a.dispatch !== b.dispatch || a.subscribe !== b.subscribe ? 1 : 0
 );
-export const ReduxStoreContext = createContext(warningObject, calculateChangedBits);
+export const defaultContext = createContext(warningObject, calculateChangedBits);
 
-export const ReduxProvider = ({ store, children }) => {
+export const ReduxProvider = ({
+  store,
+  customContext = defaultContext,
+  children,
+}) => {
   const forceUpdate = useForceUpdate();
   const state = store.getState();
   const listeners = useRef([]);
@@ -50,7 +54,7 @@ export const ReduxProvider = ({ store, children }) => {
     return unsubscribe;
   }, [store, forceUpdate]);
   return createElement(
-    ReduxStoreContext.Provider,
+    customContext.Provider,
     { value: { state, dispatch: store.dispatch, subscribe } },
     children,
   );

--- a/src/provider.js
+++ b/src/provider.js
@@ -19,7 +19,9 @@ const warningObject = {
     throw new Error('Please use <ReduxProvider store={store}>');
   },
 };
-const calculateChangedBits = () => 0;
+const calculateChangedBits = (a, b) => (
+  a.dispatch !== b.dispatch || a.subscribe !== b.subscribe ? 1 : 0
+);
 export const ReduxStoreContext = createContext(warningObject, calculateChangedBits);
 
 export const ReduxProvider = ({ store, children }) => {

--- a/src/provider.js
+++ b/src/provider.js
@@ -6,9 +6,7 @@ import {
   useRef,
 } from 'react';
 
-import { batchedUpdates } from './batchedUpdates';
-
-import { useForceUpdate } from './utils';
+import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 
 // context
 const warningObject = {
@@ -32,10 +30,8 @@ export const ReduxProvider = ({
   const forceUpdate = useForceUpdate();
   const state = store.getState();
   const listeners = useRef([]);
-  useEffect(() => {
-    batchedUpdates(() => {
-      listeners.current.forEach(listener => listener(state));
-    });
+  useIsomorphicLayoutEffect(() => {
+    listeners.current.forEach(listener => listener(state));
   }, [state]);
   const subscribe = useCallback((listener) => {
     listeners.current.push(listener);

--- a/src/useReduxDispatch.js
+++ b/src/useReduxDispatch.js
@@ -1,8 +1,11 @@
 import { useContext } from 'react';
 
-import { ReduxStoreContext } from './provider';
+import { defaultContext } from './provider';
 
-export const useReduxDispatch = () => {
-  const { dispatch } = useContext(ReduxStoreContext);
+export const useReduxDispatch = (opts = {}) => {
+  const {
+    customContext = defaultContext,
+  } = opts;
+  const { dispatch } = useContext(customContext);
   return dispatch;
 };

--- a/src/useReduxDispatch.js
+++ b/src/useReduxDispatch.js
@@ -3,6 +3,6 @@ import { useContext } from 'react';
 import { ReduxStoreContext } from './provider';
 
 export const useReduxDispatch = () => {
-  const store = useContext(ReduxStoreContext);
-  return store.dispatch;
+  const { dispatch } = useContext(ReduxStoreContext);
+  return dispatch;
 };

--- a/src/useReduxDispatch.js
+++ b/src/useReduxDispatch.js
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import { defaultContext } from './provider';
+import { defaultContext } from './ReduxProvider';
 
 export const useReduxDispatch = (opts = {}) => {
   const {

--- a/src/useReduxSelectors.js
+++ b/src/useReduxSelectors.js
@@ -50,9 +50,8 @@ const runSelector = (state, selector) => {
 
 export const useReduxSelectors = (selectorMap) => {
   const forceUpdate = useForceUpdate();
-  // redux store&state
-  const store = useContext(ReduxStoreContext);
-  const state = store.getState();
+  // redux state
+  const { state, subscribe } = useContext(ReduxStoreContext);
   // mapped result
   const keys = Object.keys(selectorMap);
   const mapped = createMap(keys, key => runSelector(state, selectorMap[key]));
@@ -64,9 +63,8 @@ export const useReduxSelectors = (selectorMap) => {
   });
   // subscription
   useEffect(() => {
-    const callback = () => {
+    const callback = (nextState) => {
       try {
-        const nextState = store.getState();
         let changed = false;
         const nextMapped = createMap(lastTracked.current.keys, (key) => {
           const lastResult = lastTracked.current.mapped[key];
@@ -86,10 +84,8 @@ export const useReduxSelectors = (selectorMap) => {
         forceUpdate();
       }
     };
-    // run once in case the state is already changed
-    callback();
-    const unsubscribe = store.subscribe(callback);
+    const unsubscribe = subscribe(callback);
     return unsubscribe;
-  }, [store]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [subscribe, forceUpdate]);
   return trapped.proxy;
 };

--- a/src/useReduxSelectors.js
+++ b/src/useReduxSelectors.js
@@ -8,7 +8,7 @@ import memoize from 'memoize-state';
 
 import { withKnowUsage } from 'with-known-usage';
 
-import { defaultContext } from './provider';
+import { defaultContext } from './ReduxProvider';
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 

--- a/src/useReduxSelectors.js
+++ b/src/useReduxSelectors.js
@@ -8,7 +8,7 @@ import memoize from 'memoize-state';
 
 import { withKnowUsage } from 'with-known-usage';
 
-import { ReduxStoreContext } from './provider';
+import { defaultContext } from './provider';
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 
@@ -48,10 +48,13 @@ const runSelector = (state, selector) => {
   return { selector, value };
 };
 
-export const useReduxSelectors = (selectorMap) => {
+export const useReduxSelectors = (selectorMap, opts = {}) => {
+  const {
+    customContext = defaultContext,
+  } = opts;
   const forceUpdate = useForceUpdate();
   // redux state
-  const { state, subscribe } = useContext(ReduxStoreContext);
+  const { state, subscribe } = useContext(customContext);
   // mapped result
   const keys = Object.keys(selectorMap);
   const mapped = createMap(keys, key => runSelector(state, selectorMap[key]));

--- a/src/useReduxState.js
+++ b/src/useReduxState.js
@@ -4,7 +4,7 @@ import {
   useRef,
 } from 'react';
 
-import { defaultContext } from './provider';
+import { defaultContext } from './ReduxProvider';
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 

--- a/src/useReduxState.js
+++ b/src/useReduxState.js
@@ -4,15 +4,18 @@ import {
   useRef,
 } from 'react';
 
-import { ReduxStoreContext } from './provider';
+import { defaultContext } from './provider';
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 
 import { createDeepProxy, isDeepChanged } from './deepProxy';
 
 export const useReduxState = (opts = {}) => {
+  const {
+    customContext = defaultContext,
+  } = opts;
   const forceUpdate = useForceUpdate();
-  const { state, subscribe } = useContext(ReduxStoreContext);
+  const { state, subscribe } = useContext(customContext);
   const affected = new WeakMap();
   const lastTracked = useRef(null);
   useIsomorphicLayoutEffect(() => {

--- a/src/useReduxState.js
+++ b/src/useReduxState.js
@@ -12,8 +12,7 @@ import { createDeepProxy, isDeepChanged } from './deepProxy';
 
 export const useReduxState = (opts = {}) => {
   const forceUpdate = useForceUpdate();
-  const store = useContext(ReduxStoreContext);
-  const state = store.getState();
+  const { state, subscribe } = useContext(ReduxStoreContext);
   const affected = new WeakMap();
   const lastTracked = useRef(null);
   useIsomorphicLayoutEffect(() => {
@@ -30,8 +29,7 @@ export const useReduxState = (opts = {}) => {
     };
   });
   useEffect(() => {
-    const callback = () => {
-      const nextState = store.getState();
+    const callback = (nextState) => {
       const changed = isDeepChanged(
         lastTracked.current.state,
         nextState,
@@ -44,11 +42,9 @@ export const useReduxState = (opts = {}) => {
         forceUpdate();
       }
     };
-    // run once in case the state is already changed
-    callback();
-    const unsubscribe = store.subscribe(callback);
+    const unsubscribe = subscribe(callback);
     return unsubscribe;
-  }, [store]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [subscribe, forceUpdate]);
   const proxyCache = useRef(new WeakMap()); // per-hook proxyCache
   return createDeepProxy(state, affected, proxyCache.current);
 };

--- a/src/useReduxStateRich.js
+++ b/src/useReduxStateRich.js
@@ -6,7 +6,7 @@ import {
 
 import { proxyState, proxyEqual } from 'proxyequal';
 
-import { ReduxStoreContext } from './provider';
+import { defaultContext } from './provider';
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 
@@ -30,10 +30,13 @@ const useTrapped = (state) => {
   return trapped;
 };
 
-export const useReduxStateRich = () => {
+export const useReduxStateRich = (opts = {}) => {
+  const {
+    customContext = defaultContext,
+  } = opts;
   const forceUpdate = useForceUpdate();
   // redux state
-  const { state, subscribe } = useContext(ReduxStoreContext);
+  const { state, subscribe } = useContext(customContext);
   // trapped
   const trapped = useTrapped(state);
   // ref

--- a/src/useReduxStateRich.js
+++ b/src/useReduxStateRich.js
@@ -6,7 +6,7 @@ import {
 
 import { proxyState, proxyEqual } from 'proxyequal';
 
-import { defaultContext } from './provider';
+import { defaultContext } from './ReduxProvider';
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 

--- a/src/useReduxStateRich.js
+++ b/src/useReduxStateRich.js
@@ -32,9 +32,8 @@ const useTrapped = (state) => {
 
 export const useReduxStateRich = () => {
   const forceUpdate = useForceUpdate();
-  // redux store&state
-  const store = useContext(ReduxStoreContext);
-  const state = store.getState();
+  // redux state
+  const { state, subscribe } = useContext(ReduxStoreContext);
   // trapped
   const trapped = useTrapped(state);
   // ref
@@ -47,8 +46,7 @@ export const useReduxStateRich = () => {
   });
   // subscription
   useEffect(() => {
-    const callback = () => {
-      const nextState = store.getState();
+    const callback = (nextState) => {
       const changed = !proxyEqual(
         lastTracked.current.state,
         nextState,
@@ -59,10 +57,8 @@ export const useReduxStateRich = () => {
         forceUpdate();
       }
     };
-    // run once in case the state is already changed
-    callback();
-    const unsubscribe = store.subscribe(callback);
+    const unsubscribe = subscribe(callback);
     return unsubscribe;
-  }, [store]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [subscribe, forceUpdate]);
   return trapped.state;
 };

--- a/src/useReduxStateSimple.js
+++ b/src/useReduxStateSimple.js
@@ -5,7 +5,7 @@ import {
   useRef,
 } from 'react';
 
-import { ReduxStoreContext } from './provider';
+import { defaultContext } from './provider';
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 
@@ -13,9 +13,12 @@ import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 // simple version: one depth comparison
 // -------------------------------------------------------
 
-export const useReduxStateSimple = () => {
+export const useReduxStateSimple = (opts = {}) => {
+  const {
+    customContext = defaultContext,
+  } = opts;
   const forceUpdate = useForceUpdate();
-  const { state, subscribe } = useContext(ReduxStoreContext);
+  const { state, subscribe } = useContext(customContext);
   const used = useRef({});
   const handler = useMemo(() => ({
     get: (target, name) => {

--- a/src/useReduxStateSimple.js
+++ b/src/useReduxStateSimple.js
@@ -5,7 +5,7 @@ import {
   useRef,
 } from 'react';
 
-import { defaultContext } from './provider';
+import { defaultContext } from './ReduxProvider';
 
 import { useIsomorphicLayoutEffect, useForceUpdate } from './utils';
 


### PR DESCRIPTION
As it went well in https://github.com/dai-shi/react-tracked, I'm trying the same technique in reactive-react-redux too.

We put redux state in context and set observedBits = 0.
This should hopefully resolve the concurrent mode issue (but who knows what is concurrent mode...)
Closes #15, unless we further see other concurrent mode issues (in this case file a new issue).