### PR TITLE
Keep selected state ref equality in useSelector with equalityFn

### DIFF
--- a/src/useSelector.js
+++ b/src/useSelector.js
@@ -18,8 +18,12 @@ export const useSelector = (selector, eqlFn, opts) => {
   } = opts || (!isFunction(eqlFn) && eqlFn) || {};
   const forceUpdate = useForceUpdate();
   const { state, subscribe } = useContext(customContext);
-  const selected = selector(state);
   const ref = useRef(null);
+  let selected = selector(state);
+  if (ref.current && equalityFn(ref.current.selected, selected)) {
+    // to keep referential equality of the selected object
+    selected = ref.current.selected;
+  }
   useIsomorphicLayoutEffect(() => {
     ref.current = {
       equalityFn,


### PR DESCRIPTION
@salazarm reported this issue in react-redux: https://github.com/reduxjs/react-redux/pull/1412

This is the same fix in reactive-react-redux. (The implementation is different because reactive-react-redux read `state` from context value.)